### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/fleetscorebot/package.json
+++ b/fleetscorebot/package.json
@@ -23,7 +23,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "resin-sdk": "^10.0.5",
-    "resin-semver": "^1.3.0"
+    "resin-semver": "^1.4.0"
   },
   "devDependencies": {
     "husky": "^0.14.3",


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)